### PR TITLE
Default endpoint to http when use_ssl = false

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -132,7 +132,13 @@ impl ChannelBuilder {
     }
 
     async fn create_client(&self) -> Result<SparkSession, Error> {
-        let endpoint = format!("https://{}:{}", self.host, self.port);
+        let endpoint = format!("http://{}:{}", self.host, self.port);
+
+        #[cfg(feature = "tls")]
+        if (self.use_ssl) {
+            endpoint = format!("https://{}:{}", self.host, self.port);
+        }
+
         let channel = Endpoint::from_shared(endpoint)?.connect().await?;
 
         let service_client = SparkConnectServiceClient::with_interceptor(

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -132,7 +132,7 @@ impl ChannelBuilder {
     }
 
     async fn create_client(&self) -> Result<SparkSession, Error> {
-        let endpoint = format!("http://{}:{}", self.host, self.port);
+        let mut endpoint = format!("http://{}:{}", self.host, self.port);
 
         if (self.use_ssl) {
             endpoint = format!("https://{}:{}", self.host, self.port);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -134,7 +134,6 @@ impl ChannelBuilder {
     async fn create_client(&self) -> Result<SparkSession, Error> {
         let endpoint = format!("http://{}:{}", self.host, self.port);
 
-        #[cfg(feature = "tls")]
         if (self.use_ssl) {
             endpoint = format!("https://{}:{}", self.host, self.port);
         }


### PR DESCRIPTION
# Description
The current spark-connect-rs library configures all endpoints to `https` scheme. When `tls` feature is enabled, connection cannot be successfully made to server without TLS configured, for example, when connecting to a Spark cluster set up at localhost

# Expected Behavior
When `tls` feature is enabled in spark-connect-rs crate, connection to server with / without TLS configured should both be successful

# Proposed Fix
Default endpoint scheme to `http`, set it to `https` only when `use_ssl=true` is specified in connection string

# Related Issue
- https://github.com/spiceai/spiceai/issues/1251
